### PR TITLE
Fix bugs related to input fasta identifiers

### DIFF
--- a/HRPredict.py
+++ b/HRPredict.py
@@ -38,7 +38,7 @@ def accession_id_get(fasta, fa_dir):
                 if num != 0:
                     output.write(">%s\n%s\n" % (pid, seq))
                     output.close()
-                pid = line.strip().split()[0][1:]
+                pid = line.strip().split()[0][1:].replace("|","_")
                 plist.append(pid)
                 output = open("{}{}.fasta".format(fa_dir, pid), 'w')
                 seq = ''
@@ -117,7 +117,7 @@ def genebank_protein_dic_get(genebank, prot_vector):
 
 def prot_dist_calculate(plasmid_id, fasta, ref_prot_dic, prot_vec, tmp_dir):
     prokka_tmp = "{}{}".format(tmp_dir, plasmid_id)
-    prokka_run = "prokka {} --outdir {} --prefix {} --kingdom Bacteria".format(fasta, prokka_tmp, plasmid_id)
+    prokka_run = "prokka {} --outdir {} --prefix {} --kingdom Bacteria --centre A --compliant".format(fasta, prokka_tmp, plasmid_id)
     prokka_gb = "{}/{}.gbk".format(prokka_tmp, plasmid_id)
     os.system(prokka_run)
     if not os.path.getsize(prokka_gb):
@@ -161,6 +161,11 @@ def host_range_output(result_dic, output, prob_F, prob_G, prob_S, lineageF, line
     FP_df = pd.read_csv(prob_F, delimiter=',')
     GP_df = pd.read_csv(prob_G, delimiter=',')
     SP_df = pd.read_csv(prob_S, delimiter=',')
+
+    # Ensure indexes are always strings, to allow integer sequence IDs
+    FP_df.index = FP_df.index.astype(str)
+    GP_df.index = GP_df.index.astype(str)
+    SP_df.index = SP_df.index.astype(str)
 
     g_dic = {}
     for h_index in range(len(lineageG)):


### PR DESCRIPTION
First, thanks for developing HRPredict, it seems very useful!

When testing HRPredict on my plasmids I discovered a few bugs related to the format of the sequence identifiers of the input fasta file:

HRPredict crashes when the identifier strings of the input has one of these characteristics:
1. Contains a pipe character ("|"). Example: `>seq348|2347392743298`
2. Is an integer. Example: `>123`
3. Is longer than 37 characters (due to prokka, see discussion [here](https://github.com/tseemann/prokka/issues/337))

This patch fixes this by:
1. Replacing all pipe characters with underscores in `accession_id_get()`
2. Explicitly setting the dataframe indices' types to str in `host_range_output()`
3. Run prokka with the `--compliant --centre` flags, as suggested in the issue linked above